### PR TITLE
Fix installation issue

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,4 +1,4 @@
-default[:dokku][:tag]  = 'v0.2.3'
+default[:dokku][:tag]  = 'v0.3.26'
 default[:dokku][:root] = '/home/dokku'
 default[:dokku][:ssh_users] = []
 default[:dokku][:vhost] = nil

--- a/recipes/app_envs.rb
+++ b/recipes/app_envs.rb
@@ -1,0 +1,14 @@
+## setup env vars for listed apps
+node[:dokku][:apps].each do |app, cfg|
+  directory File.join(node[:dokku][:root], app) do
+    owner  'dokku'
+    group  'dokku'
+  end
+
+  template File.join(node[:dokku][:root], app, 'ENV') do
+    source 'ENV.erb'
+    owner  'dokku'
+    group  'dokku'
+    variables(:env => cfg[:env] || {})
+  end
+end

--- a/recipes/bootstrap.rb
+++ b/recipes/bootstrap.rb
@@ -1,0 +1,13 @@
+## to get the bootstrap script
+package "wget"
+
+## make sure we have apt-add-repository
+package "python-software-properties"
+package "software-properties-common"
+
+url = "https://raw.github.com/progrium/dokku/#{node[:dokku][:tag]}/bootstrap.sh"
+
+bash "dokku-bootstrap" do
+  code "wget -qO- #{url} | sudo DOKKU_TAG=#{node[:dokku][:tag]} " +
+    "DOKKU_ROOT=\"#{node[:dokku][:root]}\" bash"
+end

--- a/recipes/debconf.rb
+++ b/recipes/debconf.rb
@@ -1,0 +1,23 @@
+# A SSH key is required as part of the initial installation process, so we
+# grab the first key from the first specified user. Any remaining keys are
+# also added once installation is complete.
+first_user = node[:dokku][:ssh_users].first
+ssh_key    = data_bag_item('users', first_user).fetch('ssh_keys', []).first
+key_file   = File.join(Chef::Config[:file_cache_path], "dokku_ssh_key.pub")
+
+file key_file do
+  content ssh_key
+  action :create
+end
+
+bash "dokku debconf-set-selections" do
+  code \
+    "echo \"dokku dokku/web_config boolean false\" " +
+      "| debconf-set-selections && " +
+    "echo \"dokku dokku/vhost_enable boolean true\" " +
+      "| debconf-set-selections && " +
+    "echo \"dokku dokku/hostname string #{node[:dokku][:vhost]}\" " +
+      "| debconf-set-selections && " +
+    "echo \"dokku dokku/key_file string #{key_file}\" " +
+      "| debconf-set-selections"
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -7,99 +7,10 @@
 # All rights reserved - Do Not Redistribute
 #
 
-## to get the bootstrap script
-package 'wget'
-
-## make sure we have apt-add-repository
-package 'python-software-properties'
-package 'software-properties-common'
-
-tag   = node[:dokku][:tag]
-root  = node[:dokku][:root]
-vhost = node[:dokku][:vhost]
-
-version_file = File.join(root, 'VERSION')
-authed_file  = File.join(root, ".ssh", "authorized_keys")
-
-version = File.exist?(version_file) && File.read(version_file)
-
-# If dokku is not installed, or another version than the one specified is
-# installed, run Dokku's boostrap.sh to ensure specified version is installed.
-if !version || version.strip.gsub(/^v/i, '') != tag.strip.gsub(/^v/i, '')
-  if !version
-    # A SSH key is required as part of the initial installation process, so we
-    # grab the first key from the first specified user. Any remaining keys are
-    # also added once installation is complete.
-    user      = node[:dokku][:ssh_users].first
-    ssh_key   = data_bag_item('users', user).fetch('ssh_keys', []).first
-    key_file  = File.join(Chef::Config[:file_cache_path], "dokku_ssh_key.pub")
-    file key_file do
-      content ssh_key
-      action :create
-    end
-
-    bash "dokku debconf-set-selections" do
-      code \
-        "echo \"dokku dokku/web_config boolean false\" " +
-          "| debconf-set-selections && " +
-        "echo \"dokku dokku/vhost_enable boolean true\" " +
-          "| debconf-set-selections && " +
-        "echo \"dokku dokku/hostname string #{vhost}\" " +
-          "| debconf-set-selections && " +
-        "echo \"dokku dokku/key_file string #{key_file}\" " +
-          "| debconf-set-selections"
-    end
-
-    log "about to install dokku, this can take upto 15 minutes or more."
-  end
-
-  bash "dokku-bootstrap" do
-    code "wget -qO- https://raw.github.com/progrium/dokku/#{tag}/bootstrap.sh " +
-      "| sudo DOKKU_TAG=#{tag} DOKKU_ROOT=\"#{root}\" bash"
-  end
-end
-
-## loop through users adding all their keys from data_bag users if needed
-node[:dokku][:ssh_users].each do |user|
-  keys = data_bag_item('users', user).fetch('ssh_keys', [])
-  Array(keys).each_with_index do |key, index|
-    bash 'sshcommand-acl-add' do
-      cwd root
-      code "echo '#{key}' | sshcommand acl-add dokku #{user}-#{index}"
-      not_if do
-        authed_keys  = File.exist?(authed_file) && File.read(authed_file)
-        escaped_name = Regexp.escape("#{user}-#{index}")
-        escaped_key  = Regexp.escape(key)
-
-        authed_keys && authed_keys =~ /^.+#{escaped_name}.+#{escaped_key}.*$/
-      end
-    end
-  end
-end
-
-## setup domain, you need this unless host can resolve dig +short $(hostname -f)
-if vhost
-  file File.join(root, 'VHOST') do
-    owner 'dokku'
-    content vhost
-    action :create
-  end
-end
-
-## setup env vars for listed apps
-node[:dokku][:apps].each do |app, cfg|
-  directory File.join(root, app) do
-    owner  'dokku'
-    group  'dokku'
-  end
-
-  template File.join(root, app, 'ENV') do
-    source 'ENV.erb'
-    owner  'dokku'
-    group  'dokku'
-    variables(:env => cfg[:env] || {})
-  end
-end
+include_recipe "dokku-simple::install"
+include_recipe "dokku-simple::ssh_users"
+include_recipe "dokku-simple::vhost"
+include_recipe "dokku-simple::app_envs"
 
 ## initial git push works better if we restart docker first
 service 'docker' do

--- a/recipes/disable_plugins.rb
+++ b/recipes/disable_plugins.rb
@@ -1,0 +1,10 @@
+enabled_dir  = "/var/lib/dokku/plugins"
+disabled_dir = "/var/lib/dokku/disabled-plugins"
+
+node[:dokku][:plugins].each do |name, _|
+  bash "disable-plugin:#{name}" do
+    code "mkdir -p \"#{disabled_dir}/\"; " +
+      "mv \"#{File.join(enabled_dir, name)}\" \"#{disabled_dir}/\""
+    not_if { !File.exist?(File.join(enabled_dir, name)) }
+  end
+end

--- a/recipes/enable_plugins.rb
+++ b/recipes/enable_plugins.rb
@@ -1,0 +1,9 @@
+enabled_dir  = "/var/lib/dokku/plugins"
+disabled_dir = "/var/lib/dokku/disabled-plugins"
+
+node[:dokku][:plugins].each do |name, _|
+  bash "enable-plugin:#{name}" do
+    code "mv \"#{File.join(disabled_dir, name)}\" \"#{enabled_dir}/\""
+    not_if { !File.exist?(File.join(disabled_dir, name)) }
+  end
+end

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -1,0 +1,10 @@
+tag          = node[:dokku][:tag]
+version_file = File.join(node[:dokku][:root], 'VERSION')
+version      = File.exist?(version_file) && File.read(version_file)
+
+if !version || version.strip.gsub(/^v/i, '') != tag.strip.gsub(/^v/i, '')
+  # Due to an issue with Dokku's installation process, we currently need to
+  # disable 3rd-party plugins to avoid any potential issues.
+  include_recipe "dokku-simple::debconf"
+  include_recipe "dokku-simple::bootstrap"
+end

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -5,6 +5,8 @@ version      = File.exist?(version_file) && File.read(version_file)
 if !version || version.strip.gsub(/^v/i, '') != tag.strip.gsub(/^v/i, '')
   # Due to an issue with Dokku's installation process, we currently need to
   # disable 3rd-party plugins to avoid any potential issues.
+  include_recipe "dokku-simple::disable_plugins"
   include_recipe "dokku-simple::debconf"
   include_recipe "dokku-simple::bootstrap"
+  include_recipe "dokku-simple::enable_plugins"
 end

--- a/recipes/ssh_users.rb
+++ b/recipes/ssh_users.rb
@@ -1,0 +1,19 @@
+authed_file  = File.join(node[:dokku][:root], ".ssh", "authorized_keys")
+
+## loop through users adding all their keys from data_bag users if needed
+node[:dokku][:ssh_users].each do |user|
+  keys = data_bag_item('users', user).fetch('ssh_keys', [])
+  Array(keys).each_with_index do |key, index|
+    bash 'sshcommand-acl-add' do
+      cwd node[:dokku][:root]
+      code "echo '#{key}' | sshcommand acl-add dokku #{user}-#{index}"
+      not_if do
+        authed_keys  = File.exist?(authed_file) && File.read(authed_file)
+        escaped_name = Regexp.escape("#{user}-#{index}")
+        escaped_key  = Regexp.escape(key)
+
+        authed_keys && authed_keys =~ /^.+#{escaped_name}.+#{escaped_key}.*$/
+      end
+    end
+  end
+end

--- a/recipes/vhost.rb
+++ b/recipes/vhost.rb
@@ -1,0 +1,8 @@
+## setup domain, you need this unless host can resolve dig +short $(hostname -f)
+if node[:dokku][:vhost]
+  file File.join(node[:dokku][:root], 'VHOST') do
+    owner 'dokku'
+    content node[:dokku][:vhost]
+    action :create
+  end
+end


### PR DESCRIPTION
Main goal of this PR is to a fix installation issue with dokku v0.3.13 and later which is installed via a Debian package, requiring debconf to pre-configure dokku before package installation.

Additionally an issue with 3rd-party plugins detailed in https://github.com/progrium/dokku/issues/1205 has also been worked around, by disabling all defined plugins before running dokku's `boostrap.sh` script.

And lastly, because the default recipe was starting to get bloated, I broke it apart into smaller recipes. Users should still only need to care about the `default` and `plugins` recipes however :)

@rlister, I'd like your input on these changes before we merge them. I've successfully installed 0.3.22 from scratch and plugins, and then upgraded to 0.3.26 too, testing both normal installation, upgrade installation, and upgrade with plugins which trigger the apt-get lock issue from https://github.com/progrium/dokku/issues/1205 is worked around.
